### PR TITLE
Remove Service dir and use a Transform to filter the rbd-nbd.exe

### DIFF
--- a/Filter.xsl
+++ b/Filter.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
+
+<xsl:output method="xml" indent="yes" />
+
+<xsl:template match="@*|node()">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:key name="rbd-nbd-search" match="wix:Component[contains(wix:File/@Source, 'rbd-nbd.exe')]" use="@Id" />
+<xsl:template match="wix:Component[key('rbd-nbd-search', @Id)]" />
+
+</xsl:stylesheet>

--- a/Product.wxs
+++ b/Product.wxs
@@ -65,10 +65,6 @@
     </DirectoryRef>
 
     <DirectoryRef Id="INSTALLDIR">
-      <Directory Id="SERVICEDIR" Name="service" />
-    </DirectoryRef>
-
-    <DirectoryRef Id="INSTALLDIR">
       <Directory Id="DRIVERDIR" Name="driver" />
     </DirectoryRef>
 
@@ -86,8 +82,8 @@
   </Fragment>
   <Fragment>
 
-    <Component Id="CephRbdService" Directory="SERVICEDIR" Guid="{280201D5-35E7-45D6-83B9-293F1A4F7F0D}">
-      <File Id="RbdNbd.exe" Source="Service\rbd-nbd.exe" KeyPath="yes" Checksum="yes" />
+    <Component Id="CephRbdService" Directory="BINARIESDIR" Guid="{280201D5-35E7-45D6-83B9-293F1A4F7F0D}">
+      <File Id="RbdNbd.exe" Source="Binaries\rbd-nbd.exe" KeyPath="yes" Checksum="yes" />
       <ServiceInstall
                 Arguments='service'
                 Id="CephRbdServiceInstaller"

--- a/Service/.gitignore
+++ b/Service/.gitignore
@@ -1,5 +1,0 @@
-*
-*/
-!.gitignore
-!ceph.conf
-!ceph.client.admin.keyring

--- a/ceph-windows-installer.wixproj
+++ b/ceph-windows-installer.wixproj
@@ -10,7 +10,7 @@
     <OutputType>Package</OutputType>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
-	<DefineSolutionProperties>false</DefineSolutionProperties>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -38,7 +38,6 @@
     <Folder Include="images\" />
     <Folder Include="Actions" />
     <Folder Include="Driver" />
-    <Folder Include="Services" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Actions\CephActions.js" />
@@ -58,7 +57,7 @@
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <Target Name="BeforeBuild">
-    <HeatDirectory DirectoryRefId="BINARIESDIR" OutputFile="Binaries.wxs" Directory="Binaries" ComponentGroupName="BinariesComponentGroup" ToolPath="$(WixToolPath)" PreprocessorVariable="var.BinariesPath" GenerateGuidsNow="true" SuppressCom="true" SuppressRegistry="true" KeepEmptyDirectories="true" SuppressRootDirectory="true">
+    <HeatDirectory DirectoryRefId="BINARIESDIR" Transforms="Filter.xsl" OutputFile="Binaries.wxs" Directory="Binaries" ComponentGroupName="BinariesComponentGroup" ToolPath="$(WixToolPath)" PreprocessorVariable="var.BinariesPath" GenerateGuidsNow="true" SuppressCom="true" SuppressRegistry="true" KeepEmptyDirectories="true" SuppressRootDirectory="true">
     </HeatDirectory>
   </Target>
 </Project>


### PR DESCRIPTION
If rbd-nbd.exe is not filtered out from the harvester HeatDir,
an error will be thrown when building the installer:

error LGHT0204: ICE30: The target file 'rbd-nbd.exe' is installed
in '[ProgramFiles64Folder]\Ceph\bin\' by two different components
on an SFN system. This breaks component reference counting.