### PR TITLE
Clean rbd-wnbd mappings on uninstall

### DIFF
--- a/Product.wxs
+++ b/Product.wxs
@@ -25,13 +25,18 @@
            include both WNBD and Ceph symbols. -->
       <ComponentGroupRef Id="SymbolsComponentGroup" />
       <!-- Force delete mappings on uninstall-->
-      <Component Id="CleanRbdWnbdMappings"
+      <Component Id="CleanRegistry"
                  Directory="TARGETDIR"
                  Guid="{280201D5-35E7-45D6-83B9-577EA1597BB5}"
                  KeyPath="yes">
-        <RegistryKey Id="CleanupRegistry"
+        <RegistryKey Id="CleanupRegistryRbd"
                      Root="HKLM"
                      Key="SYSTEM\CurrentControlSet\Services\rbd-wnbd"
+                     ForceDeleteOnUninstall="yes"
+                     Action="createAndRemoveOnUninstall"/>
+        <RegistryKey Id="CleanupRegistryWnbd"
+                     Root="HKLM"
+                     Key="SYSTEM\CurrentControlSet\Services\wnbd"
                      ForceDeleteOnUninstall="yes"
                      Action="createAndRemoveOnUninstall"/>
       </Component>

--- a/Product.wxs
+++ b/Product.wxs
@@ -24,6 +24,17 @@
       <!-- TODO: Consider using a separate feature for the symbols. This folder might
            include both WNBD and Ceph symbols. -->
       <ComponentGroupRef Id="SymbolsComponentGroup" />
+      <!-- Force delete mappings on uninstall-->
+      <Component Id="CleanRbdWnbdMappings"
+                 Directory="TARGETDIR"
+                 Guid="{280201D5-35E7-45D6-83B9-577EA1597BB5}"
+                 KeyPath="yes">
+        <RegistryKey Id="CleanupRegistry"
+                     Root="HKLM"
+                     Key="SYSTEM\CurrentControlSet\Services\rbd-wnbd"
+                     ForceDeleteOnUninstall="yes"
+                     Action="createAndRemoveOnUninstall"/>
+      </Component>
       <Feature Id="VC142Redist" Title="Visual C++ 19 Runtime" AllowAdvertise="no"
                Display="hidden" Level="1" Absent="disallow" InstallDefault="followParent"
                TypicalDefault="install">


### PR DESCRIPTION
Currently on uninstall all unmapped mappings will exist after uninstall.

This PR removes the following registry trees

> `HKLM\SYSTEM\CurrentControlSet\Services\rbd-wnbd` (mappings)

> `HKLM\SYSTEM\CurrentControlSet\Services\wnbd` (driver configuration) 

on uninstall.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>