### PR TITLE
Create required directories and include debugging tool and symbols

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -154,8 +154,12 @@ if ((Test-Path $depsBuildDir) -and !$RetainDependenciesBuildDir) {
 
 mkdir -Force $depsBuildDir
 
-del Driver\*
-del Binaries\*
+$RequiredDirs = "Driver", "Binaries", "Symbols"
+foreach ($dir in $RequiredDirs)
+{
+    mkdir -Force $dir
+    del $dir\*
+}
 
 if($UseWSL) {
     BuildCephWSL

--- a/Build.ps1
+++ b/Build.ps1
@@ -88,6 +88,10 @@ function BuildWnbd() {
 
     copy vstudio\x64\Release\driver\* ..\..\Driver\
     copy vstudio\x64\Release\libwnbd.dll ..\..\Binaries\
+    copy vstudio\x64\Release\wnbd-client.exe ..\..\Binaries\
+    copy vstudio\x64\Release\pdb\driver\* ..\..\Symbols\
+    copy vstudio\x64\Release\pdb\libwnbd\* ..\..\Symbols\
+    copy vstudio\x64\Release\pdb\wnbd-client\* ..\..\Symbols\
 
     popd
 }


### PR DESCRIPTION
The Driver, Binaries and Symbols directories are all required in order for the build to succeed. Create these automatically, and ensure they are empty prior to the build.

Also, include wnbd-client.exe and pdb files for troubleshooting purposes.