### PR TITLE
Fixes Build.ps1

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -131,7 +131,7 @@ function BuildCephWSL() {
     pushd $depsBuildDir
 
     if (!(Test-Path ceph)) {
-        & git.exe -c core.symlinks=true clone --recurse-submodules $CephRepoUrl $CephRepoBranch
+        & wsl.exe -d $WSLDistro -u root -e bash -c "git -c core.symlinks=true clone --recurse-submodules $CephRepoUrl -b $CephRepoBranch"
         if($LASTEXITCODE) {
             throw "git failed"
         }

--- a/Build.ps1
+++ b/Build.ps1
@@ -153,7 +153,7 @@ SetVCVars
 
 if ((Test-Path $depsBuildDir) -and !$RetainDependenciesBuildDir) {
     Write-Output "Removing dependencies build dir"
-    rm -Recurse -Force $depsBuildDir\
+    cmd /c rmdir /s /q $depsBuildDir\
 }
 
 mkdir -Force $depsBuildDir

--- a/Build.ps1
+++ b/Build.ps1
@@ -15,7 +15,7 @@ Param(
     [Parameter(ParameterSetName="CephWSL")]
     [Parameter(ParameterSetName="CephWSLSign")]
     [ValidateNotNullOrEmpty()]
-    [string]$CephRepoBranch = "windows.12",
+    [string]$CephRepoBranch = "wnbd_dev",
 
     # Archive containing the Ceph Windows binaries, will be fetched using scp.
     # Can be a local path, a UNC path or a remote scp path.


### PR DESCRIPTION
- Fix git clone call

- Switch to a new default branch

- Remove-Item does not work on junctions. Replace `Remove-Item` with `rmdir`