### PR TITLE
Copy binaries from "bin" instead of "bin_stripped"

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -162,7 +162,7 @@ function BuildCephWSL($includeDebugSymbols, $minimalDebugInfo) {
         throw "Ceph WSL build failed"
     }
 
-    CopyCephBinaries "build\bin_stripped" "..\..\Binaries\"
+    CopyCephBinaries "build\bin" "..\..\Binaries\"
     popd
 }
 


### PR DESCRIPTION
We're no longer using the "STRIP_ZIPPED" flag, so we'll need to
update the path used for copying the Ceph binaries.