### PR TITLE
Use wnbd-client to install/uninstall the driver

### DIFF
--- a/Actions/CephActions.js
+++ b/Actions/CephActions.js
@@ -256,32 +256,3 @@ function changeServiceAction() {
         return MsiActionStatus.Abort;
     }
 }
-
-function removeDriverWithPnputil() {
-    var exceptionMsg = null;
-
-    try {
-        var data = Session.Property("CustomActionData").split('|');
-        var i = 0;
-        var driverName = data[i++];
-        var expectedRetValue = data.length > i ? data[i++] : 0;
-        var exceptionMsg = data.length > i ? data[i++] : null;
-        var workingDir = data.length > i ? data[i++] : null;
-        var cmd = "powershell pnputil.exe /enum-drivers | sls -Context 7 "
-        cmd += driverName
-        cmd += " | findstr Published | Foreach-Object {pnputil /delete-driver $_.replace('Published Name:','').trim()}"
-
-        runCommand(cmd, expectedRetValue, null, 0, true, workingDir);
-        return MsiActionStatus.Ok;
-    } catch (ex) {
-        if (exceptionMsg) {
-            logMessageEx(ex.message, MsgKind.Error + Icons.Critical + Buttons.OkOnly);
-            // log also the original exception
-            logMessage(ex.message);
-        } else {
-            logException(ex);
-        }
-
-        return MsiActionStatus.Abort;
-    }
-}

--- a/Build.ps1
+++ b/Build.ps1
@@ -116,11 +116,11 @@ function CopyCephBinaries($sourcePath, $targetPath) {
     popd
 }
 
-function GetCephBinaries() {
+function GetCephBinaries($cephZipPath) {
     pushd $depsBuildDir
 
     if (!(Test-Path cephzip)) {
-        & scp.exe $CephZipPath ceph.zip
+        & scp.exe $cephZipPath ceph.zip
         if($LASTEXITCODE) {
             throw "scp failed"
         }
@@ -164,7 +164,9 @@ function BuildCephWSL($includeDebugSymbols, $minimalDebugInfo) {
         throw "Ceph WSL build failed"
     }
 
-    CopyCephBinaries "build\bin" "..\..\Binaries\"
+    $CephZipPath = (Resolve-Path "build\ceph.zip").Path
+    GetCephBinaries -cephZipPath $CephZipPath
+
     popd
 }
 
@@ -184,14 +186,14 @@ $RequiredDirs = "Driver", "Binaries", "Symbols"
 foreach ($dir in $RequiredDirs)
 {
     mkdir -Force $dir
-    del $dir\*
+    del -Recurse $dir\*
 }
 
 if($UseWSL) {
     BuildCephWSL -includeDebugSymbols $IncludeCephDebugSymbols `
                  -minimalDebugInfo $MinimalCephDebugInfo
 } else {
-    GetCephBinaries
+    GetCephBinaries -cephZipPath $CephZipPath
 }
 
 BuildWnbd

--- a/CustomActions.wxs
+++ b/CustomActions.wxs
@@ -4,7 +4,7 @@
     <Binary Id="CephActions" SourceFile="Actions\CephActions.js" />
 
     <CustomAction Id="InstallWindowsCephDriver_Prop" Property="InstallWindowsCephDriver"
-                  Value='"[BINARIESDIR]devcon.exe" install "[DRIVERDIR]\wnbd.inf" "root\wnbd"|0|devcon failed to install the Windows Ceph RBD NBD driver'
+                  Value='"[BINARIESDIR]wnbd-client.exe" install-driver "[DRIVERDIR]\wnbd.inf"|0|Failed to install the Windows Ceph RBD WNBD driver. A reboot might be required. Check the MSI log for more details.'
                   Execute="immediate" />
     <CustomAction Id="InstallWindowsCephDriver"
               BinaryKey="CephActions"
@@ -18,18 +18,11 @@
                   JScriptCall="runCommandAction" Execute="deferred" Return="check" Impersonate="no" />
 
     <CustomAction Id="UninstallWindowsCephDriver_Prop" Property="UninstallWindowsCephDriver"
-                  Value='"[BINARIESDIR]devcon.exe" remove "root\wnbd"|0|devcon failed to uninstall the Windows Ceph RBD NBD driver'
+                  Value='"[BINARIESDIR]wnbd-client.exe" uninstall-driver|0|Failed to uninstall the Windows Ceph RBD WNBD driver'
                   Execute="immediate" />
     <CustomAction Id="UninstallWindowsCephDriver"
               BinaryKey="CephActions"
               JScriptCall="runCommandAction" Execute="deferred" Return="check" Impersonate="no" />
-
-    <CustomAction Id="UninstallWindowsCephDriverPnputil_Prop" Property="UninstallWindowsCephDriverPnputil"
-                  Value='wnbd|0|pnputil failed to uninstall the Windows Ceph RBD NBD driver'
-                  Execute="immediate" />
-    <CustomAction Id="UninstallWindowsCephDriverPnputil"
-              BinaryKey="CephActions"
-              JScriptCall="removeDriverWithPnputil" Execute="deferred" Return="check" Impersonate="no" />
 
     <CustomAction Id="UninstallWindowsWnbdEtwEvents_Prop" Property="UninstallWindowsWnbdEtwEvents"
                   Value='"[System64Folder]wevtutil.exe" um "[BINARIESDIR]\wnbdevents.xml"|0|wevutil failed to uninstall the Windows WNBD ETW events'

--- a/Product.wxs
+++ b/Product.wxs
@@ -74,10 +74,7 @@
       <Custom Action="StartWindowsCephDriver" Before="InstallFinalize" ><![CDATA[REMOVE <> "ALL" AND (&WindowsCephDriver = 3)]]></Custom>
 
       <Custom Action="UninstallWindowsCephDriver_Prop" After="CostFinalize"><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
-      <Custom Action="UninstallWindowsCephDriver" Before="UninstallWindowsCephDriverPnputil" ><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
-
-      <Custom Action="UninstallWindowsCephDriverPnputil_Prop" After="CostFinalize"><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
-      <Custom Action="UninstallWindowsCephDriverPnputil" Before="UninstallWindowsWnbdEtwEvents" ><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
+      <Custom Action="UninstallWindowsCephDriver" Before="UninstallWindowsWnbdEtwEvents"><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
 
       <Custom Action="UninstallWindowsWnbdEtwEvents_Prop" After="CostFinalize"><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
       <Custom Action="UninstallWindowsWnbdEtwEvents" Before="RemoveFiles" ><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>


### PR DESCRIPTION
Failed driver installs can leak WNBD adapters that don't have an
associated driver or class. Those stale adapters can impact libwnbd and
the driver.

wnbd-client includes extra checks compared to devcon, also doing
a rollback on failed installs. Rather than including the same checks
here and overcomplicate the install sequence, it's much more convenient
to just use wnbd-client to install/uninstall the driver.

Note that the VC runtime required by wnbd-client gets installed before
the custom actions get executed.

As a side effect, this also fixes an issue where the the currently used
commands where failing because of a non-zero findstr exit code.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>