### PR TITLE
Avoid using relative "Dependencies" path

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -171,7 +171,7 @@ function BuildCephWSL($includeDebugSymbols, $minimalDebugInfo) {
 }
 
 cd $PSScriptRoot
-$depsBuildDir = "Dependencies"
+$depsBuildDir = (Resolve-Path "Dependencies").Path
 
 SetVCVars
 


### PR DESCRIPTION
We're using a relative path for the "Dependencies" dir. This patch
will retrieve the full path so that it may be used from different
locations.

"BuildCephWSL" is currently failing because of this.