### PR TITLE
Retry signtool command

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -48,6 +48,7 @@ Param(
 )
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\BuildUtils.ps1"
 
 function SetVCVars($version="2019", $platform="x86_amd64") {
     pushd "$ENV:ProgramFiles (x86)\Microsoft Visual Studio\$version\Community\VC\Auxiliary\Build"
@@ -65,8 +66,11 @@ function SetVCVars($version="2019", $platform="x86_amd64") {
 }
 
 function Sign($x509thumbprint, $crossCertPath, $timestampUrl, $path) {
-    & signtool.exe sign /ac $crossCertPath /sha1 $x509thumbprint /tr $timestampUrl /td SHA256 /v $path
-    if($LASTEXITCODE) { throw "signtool failed" }
+    ExecRetry {
+        & signtool.exe sign /ac $crossCertPath /sha1 $x509thumbprint `
+                            /tr $timestampUrl /td SHA256 /v $path
+        if ($LASTEXITCODE) { throw "signtool failed" }
+    }
 }
 
 function BuildWnbd() {

--- a/BuildUtils.ps1
+++ b/BuildUtils.ps1
@@ -1,0 +1,25 @@
+function ExecRetry($command, $maxRetryCount = 10, $retryInterval=2)
+{
+    $currErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    $retryCount = 0
+    while ($true) {
+        try {
+            & $command
+            break
+        }
+        catch [System.Exception] {
+            $retryCount++
+            if ($retryCount -ge $maxRetryCount) {
+                $ErrorActionPreference = $currErrorActionPreference
+                throw
+            } else {
+                Write-Error $_.Exception
+                Start-Sleep $retryInterval
+            }
+        }
+    }
+
+    $ErrorActionPreference = $currErrorActionPreference
+}


### PR DESCRIPTION
We often get driver signing errors due to the timestamp server.
This change introduces some retries.