### PR TITLE
Use upstream Pacific branch

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -11,11 +11,11 @@ Param(
     [Parameter(ParameterSetName="CephWSL")]
     [Parameter(ParameterSetName="CephWSLSign")]
     [ValidateNotNullOrEmpty()]
-    [string]$CephRepoUrl = "https://github.com/petrutlucian94/ceph",
+    [string]$CephRepoUrl = "https://github.com/ceph/ceph",
     [Parameter(ParameterSetName="CephWSL")]
     [Parameter(ParameterSetName="CephWSLSign")]
     [ValidateNotNullOrEmpty()]
-    [string]$CephRepoBranch = "wnbd_dev",
+    [string]$CephRepoBranch = "pacific",
 
     # Archive containing the Ceph Windows binaries, will be fetched using scp.
     # Can be a local path, a UNC path or a remote scp path.


### PR DESCRIPTION
Use upstream Pacific branch

At the moment, we're using a downstream Ceph branch by default.
This is no longer necessary as all the required patches have
merged. Furthermore, it's no longer compatible with the latest
Ceph Pacific version (messaging protocol changes).

We'll use the tip of the upstream Pacific branch by default.