### PR TITLE
Fix `Build.ps1` script

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -180,7 +180,7 @@ function BuildCephWSL($includeDebugSymbols, $minimalDebugInfo) {
 }
 
 cd $PSScriptRoot
-$depsBuildDir = (Resolve-Path "Dependencies").Path
+$depsBuildDir = "${PSScriptRoot}\Dependencies"
 
 SetVCVars
 


### PR DESCRIPTION
If the `Dependencies` directory doesn't exist, the following piece of code will fail:

```
$depsBuildDir = (Resolve-Path "Dependencies").Path
```

with:

```
Resolve-Path : Cannot find path 'C:\Users\Administrator\Desktop\ceph-windows-installer\Dependencies' because it does not exist.
At C:\Users\Administrator\Desktop\ceph-windows-installer\Build.ps1:183 char:18
+ $depsBuildDir = (Resolve-Path "Dependencies").Path
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Admini...er\Dependencies:String) [Resolve-Path], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand
```

Use `$PSScriptRoot` to get the absolute path of the `Build.ps1` script.