### PR TITLE
Fix BinariesFilter.xsl

### DIFF
--- a/BinariesFilter.xsl
+++ b/BinariesFilter.xsl
@@ -13,7 +13,7 @@ xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
 
 <!-- We're using this filter to avoid duplicating the rbd-wnbd component,
      which is also used by the service component. -->
-<xsl:key name="rbd-wnbd-search" match="wix:Component[contains(wix:File/@Source, 'rbd-wnbd.exe')]" use="@Id" />
+<xsl:key name="rbd-wnbd-search" match="wix:Component[substring(wix:File/@Source, string-length(wix:File/@Source)-11)='rbd-wnbd.exe']" use="@Id" />
 <xsl:template match="wix:Component[key('rbd-wnbd-search', @Id)]" />
 
 </xsl:stylesheet>


### PR DESCRIPTION
Using `contains` would exclude the `rbd-wnbd.exe` debug symbol file as well:
`<CEPH_INSTALL_DIR>\bin\.debug\rbd-wnbd.exe.debug`

This change will make `BinariesFilter.xsl` to only exclude
`<CEPH_INSTALL_DIR>\bin\rbd-wnbd-exe` file.