### PR TITLE
Schedule a reboot after (un)installing the driver

### DIFF
--- a/Product.wxs
+++ b/Product.wxs
@@ -78,6 +78,11 @@
 
       <Custom Action="UninstallWindowsWnbdEtwEvents_Prop" After="CostFinalize"><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
       <Custom Action="UninstallWindowsWnbdEtwEvents" Before="RemoveFiles" ><![CDATA[(&WindowsCephDriver=2) AND (!WindowsCephDriver=3)]]></Custom>
+      <!-- Schedule a reboot after installing or uninstalling the driver. -->
+      <ScheduleReboot After="InstallFinalize">
+        <![CDATA[(REMOVE <> "ALL" AND (&WindowsCephDriver = 3)) OR ((&WindowsCephDriver=2) AND (!WindowsCephDriver=3))]]>
+      </ScheduleReboot>
+
     </InstallExecuteSequence>
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />

--- a/UI.wxs
+++ b/UI.wxs
@@ -35,7 +35,7 @@
       <!-- Force elevation during change for product customization-->
       <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Property="REINSTALL" Value="ALL">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Property="REINSTALLMODE" Value="vamus">1</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Property="REBOOT" Value="ReallySuppress">1</Publish>
+      <!-- <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Property="REBOOT" Value="ReallySuppress">1</Publish> -->
 
       <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>


### PR DESCRIPTION
The WNBD driver can fail to install if the host hasn't been rebooted after a previous version was uninstalled. At the same time, the adapter may be unavailable if a reboot is required after a successful install.

To improve the user experience, we'll always ask for a reboot after installing or uninstalling the driver.