### PR TITLE
Add version variables

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -17,6 +17,11 @@ Param(
     [ValidateNotNullOrEmpty()]
     [string]$CephRepoBranch = "pacific",
 
+    # Example: 16.0.0.0, default: 1.0.0.0.
+    [string]$CephMsiVersion,
+    # Example: Reef. If specified, it will be included in the product name.
+    [string]$CephRelease,
+
     # Archive containing the Ceph Windows binaries, will be fetched using scp.
     # Can be a local path, a UNC path or a remote scp path.
     [Parameter(ParameterSetName="CephZipPath", Mandatory=$true)]
@@ -208,7 +213,9 @@ if($UseWSL) {
 BuildWnbd
 
 $configuration = "Release"
-& msbuild.exe ceph-windows-installer.sln /p:Platform=x64 /p:Configuration=$configuration
+& msbuild.exe ceph-windows-installer.sln `
+    /p:Platform=x64 /p:Configuration=$configuration `
+    /p:CephMsiVersion=$CephMsiVersion /p:CephRelease=$CephRelease
 if($LASTEXITCODE) {
     throw "msbuild failed"
 }

--- a/Product.wxs
+++ b/Product.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="{785B1085-EF9D-4566-A522-50F400273F07}" Name="Ceph for Windows" Language="1033" Version="1.0.0.0"
+  <Product Id="{785B1085-EF9D-4566-A522-50F400273F07}" Name="$(var.CephProductName)" Language="1033" Version="$(var.CephMsiVersion)"
            Manufacturer="Ceph" UpgradeCode="5d5011f3-f107-4739-ad84-3d49dfebd221">
     <Package InstallerVersion="405" Compressed="yes" InstallScope="perMachine" InstallPrivileges="elevated" Platform="x64" />
 

--- a/ceph-windows-installer.wixproj
+++ b/ceph-windows-installer.wixproj
@@ -18,7 +18,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>BinariesPath=Binaries;SymbolsPath=Symbols;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CephMsiVersion Condition=" '$(CephMsiVersion)' == '' ">1.0.0.0</CephMsiVersion>
+    <CephProductName Condition=" '$(CephRelease)' == '' ">Ceph for Windows</CephProductName>
+    <CephProductName Condition=" '$(CephRelease)' != '' ">Ceph for Windows ($(CephRelease))</CephProductName>
+    <DefineConstants>BinariesPath=Binaries;SymbolsPath=Symbols;CephMsiVersion=$(CephMsiVersion);CephProductName=$(CephProductName)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Binaries.wxs" />


### PR DESCRIPTION
At the moment, the MSI product version is hard-coded to 1.0.0.0. We'll make it configurable through "CephMsiVersion".

We're also adding a "CephRelease" variable that will be included in the product name, if set.

Exmaple:

```
.\Build.ps1 -CephZipPath $zipPath `
  -CephMsiVersion "18.5.0.0" -CephRelease "Reef"
```