### PR TITLE
Build.ps1: Fix version defaults

### DIFF
--- a/ceph-windows-installer.wixproj
+++ b/ceph-windows-installer.wixproj
@@ -20,10 +20,11 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
-    <CephMsiVersion Condition=" '$(CephMsiVersion)' == '' ">1.0.0.0</CephMsiVersion>
+    <CephMsiVersionSafe Condition=" '$(CephMsiVersion)' == '' ">1.0.0.0</CephMsiVersionSafe>
+    <CephMsiVersionSafe Condition=" '$(CephMsiVersion)' != '' ">$(CephMsiVersion)</CephMsiVersionSafe>
     <CephProductName Condition=" '$(CephRelease)' == '' ">Ceph for Windows</CephProductName>
     <CephProductName Condition=" '$(CephRelease)' != '' ">Ceph for Windows ($(CephRelease))</CephProductName>
-    <DefineConstants>BinariesPath=Binaries;SymbolsPath=Symbols;CephMsiVersion=$(CephMsiVersion);CephProductName=$(CephProductName)</DefineConstants>
+    <DefineConstants>BinariesPath=Binaries;SymbolsPath=Symbols;CephMsiVersion=$(CephMsiVersionSafe);CephProductName=$(CephProductName)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Binaries.wxs" />


### PR DESCRIPTION
The "CephMsiVersion" default isn't applied if this property is explicitly passed as an empty string.

To solve this, we'll use an intermediary variable, taking either the value of CephMsiVersion or the default value.